### PR TITLE
fix: restricting characters in template

### DIFF
--- a/visualizations/list-view/formatters/d.js
+++ b/visualizations/list-view/formatters/d.js
@@ -38,6 +38,7 @@ const D = (datetime, format) => {
   /* eslint-disable prefer-template */
   const formatter = {
     yy: String(y).slice(-2),
+    yyy: String(y).slice(-2) + 'y',
     yyyy: String(y),
     M: String(mo + 1),
     MM: ('0' + (mo + 1)).slice(-2),

--- a/visualizations/list-view/formatters/n.js
+++ b/visualizations/list-view/formatters/n.js
@@ -2,7 +2,7 @@
 const N = (num, opts) => {
   if (!num && num !== 0) return '';
   if (!opts) return new Intl.NumberFormat('default').format(num);
-  const parts = opts.split(';').map((o) => o.trim());
+  const parts = opts.split('>').map((o) => o.trim());
   const locale = parts.length > 1 ? parts[1] : 'default';
   const [intOpts, fracOpts] = parts[0].split('.');
   const options = {};

--- a/visualizations/list-view/tmpl8.js
+++ b/visualizations/list-view/tmpl8.js
@@ -1,13 +1,14 @@
-const tmpl8 = (template, attributes) => {
+const tmpl8 = (templateString, attributesList) => {
   try {
-    let templateStr = `const D=(e,t)=>{const s=new Date(e);if(!t)return s.toString();const r=s.getFullYear(),i=s.getMonth(),n=s.getDate(),d=s.getDay(),c=s.getHours(),g=s.getMinutes(),y=s.getSeconds(),M=s.getMilliseconds(),a=["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],l=["January","February","March","April","May","June","July","August","September","October","November","December"],u={yy:String(r).slice(-2),yyyy:String(r),M:String(i+1),MM:("0"+(i+1)).slice(-2),MMM:l[i].slice(0,3),MMMM:l[i],d:String(n),dd:("0"+n).slice(-2),ddd:a[d].slice(0,3),dddd:a[d],H:String(c),HH:("0"+c).slice(-2),h:String(c%12||12),hh:("0"+(c%12||12)).slice(-2),t:c<12?"A":"P",tt:c<12?"AM":"PM",m:String(g),mm:("0"+g).slice(-2),s:String(y),ss:("0"+y).slice(-2),sss:("00"+M).slice(-3)};return t.replace(/\\[([^\\]]+)]|y{2,4}|M{1,4}|d{1,4}|H{1,2}|h{1,2}|t{1,2}|m{1,2}|s{1,3}/g,((e,t)=>t||u[e]))};`;
-    templateStr += `const N=(t,i)=>{if(!t&&0!==t)return"";if(!i)return new Intl.NumberFormat("default").format(t);const e=i.split(";").map((t=>t.trim())),m=e.length>1?e[1]:"default",[r,n]=e[0].split(".");let s={};if(r){const[t,i,e]=r.match(/[ ]*(\\+?)[ ]*(\\d*)/);i&&(s.signDisplay="always");const m=Number(e);Number.isInteger(m)&&m>0&&m<22&&(s.minimumIntegerDigits=m)}if(n){const[t,i]=n.split(",").map(Number);Number.isInteger(t)&&t>-1&&t<21&&(s.minimumFractionDigits=t),Number.isInteger(i)&&i>-1&&i<21&&(s.maximumFractionDigits=i)}return new Intl.NumberFormat(m,s).format(t)};`;
-    templateStr += `const B=(t,e)=>{if(t=Number(t),!e)return t;const r=["byte","kilobyte","megabyte","gigabyte","terabyte","petabyte"],a=r.reduce(((t,e,r)=>({...t,[r?e.charAt(0)+"b":"b"]:Math.pow(1024,r)})),{}),[b,n,o]=e.match(/[ ]*([kmgtp]?b)[ ]*>?[ ]*([kmgtp]?b)?[ ]*/i),m=(o||n).toLowerCase(),u=o?Math.floor(t*a[n]):t,c=r[r.findIndex((t=>t.charAt(0)===m.charAt(0)))];return new Intl.NumberFormat("default",{style:"unit",unit:c}).format(u/a[m])};`;
-    templateStr += `const {${attributes
+    let fnStr = `const D=(e,t)=>{const s=new Date(e);if(!t)return s.toString();const r=s.getFullYear(),i=s.getMonth(),n=s.getDate(),y=s.getDay(),d=s.getHours(),c=s.getMinutes(),g=s.getSeconds(),M=s.getMilliseconds(),a=["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],l=["January","February","March","April","May","June","July","August","September","October","November","December"],u={yy:String(r).slice(-2),yyy:String(r).slice(-2)+"y",yyyy:String(r),M:String(i+1),MM:("0"+(i+1)).slice(-2),MMM:l[i].slice(0,3),MMMM:l[i],d:String(n),dd:("0"+n).slice(-2),ddd:a[y].slice(0,3),dddd:a[y],H:String(d),HH:("0"+d).slice(-2),h:String(d%12||12),hh:("0"+(d%12||12)).slice(-2),t:d<12?"A":"P",tt:d<12?"AM":"PM",m:String(c),mm:("0"+c).slice(-2),s:String(g),ss:("0"+g).slice(-2),sss:("00"+M).slice(-3)};return t.replace(/\\[([^\\]]+)]|y{2,4}|M{1,4}|d{1,4}|H{1,2}|h{1,2}|t{1,2}|m{1,2}|s{1,3}/g,((e,t)=>t||u[e]))};`;
+    fnStr += `const N=(t,i)=>{if(!t&&0!==t)return"";if(!i)return new Intl.NumberFormat("default").format(t);const m=i.split(">").map((t=>t.trim())),r=m.length>1?m[1]:"default",[e,n]=m[0].split("."),s={};if(e){const[t,i,m]=e.match(/[ ]*(\\+?)[ ]*(\\d*)/);i&&(s.signDisplay="always");const r=Number(m);Number.isInteger(r)&&r>0&&r<22&&(s.minimumIntegerDigits=r)}if(n){const[t,i]=n.split(",").map(Number);Number.isInteger(t)&&t>-1&&t<21&&(s.minimumFractionDigits=t),Number.isInteger(i)&&i>-1&&i<21&&(s.maximumFractionDigits=i)}return new Intl.NumberFormat(r,s).format(t)};`;
+    fnStr += `const B=(t,e)=>{if(t=Number(t),!e)return t;const r=["byte","kilobyte","megabyte","gigabyte","terabyte","petabyte"],a=r.reduce(((t,e,r)=>({...t,[r?e.charAt(0)+"b":"b"]:Math.pow(1024,r)})),{}),[b,n,o]=e.match(/[ ]*([kmgtp]?b)[ ]*>?[ ]*([kmgtp]?b)?[ ]*/i),m=(o||n).toLowerCase(),u=o?Math.floor(t*a[n]):t,c=r[r.findIndex((t=>t.charAt(0)===m.charAt(0)))];return new Intl.NumberFormat("default",{style:"unit",unit:c}).format(u/a[m])};`;
+    fnStr += `const {${attributesList
       .filter((a) => !/[\W_]+/g.test(a))
       .join(',')}} = data;let str='`;
 
-    templateStr += template
+    fnStr += templateString
+      .replace(/[^a-z0-9 ~!@#$%^&*\-+={}|\\:,>.?/]/gi, '')
       .replace(/\{\{\?\s*([\s\S]*?)\s*\}\}/g, (_match, arg) =>
         arg ? `';if (${arg}){str+='` : `';}str+='`
       )
@@ -32,9 +33,9 @@ const tmpl8 = (template, attributes) => {
       .replace(/\t/g, '\\t')
       .replace(/\r/g, '\\r');
 
-    templateStr += `'; return str;`;
+    fnStr += `'; return str;`;
 
-    return new Function('data', templateStr); // eslint-disable-line no-new-func
+    return new Function('data', fnStr); // eslint-disable-line no-new-func
   } catch (e) {
     throw new Error(`Templating Error: ${e.message}`);
   }


### PR DESCRIPTION
- restrict characters that are passed to the template
- handles `yyy` as a token when parsing dates in `tmpl8` (used to return `undefined`)
- switch from using `;` to `>` to pass locale for numbers in `tmpl8`